### PR TITLE
Bash script, not sh

### DIFF
--- a/check_jstat.sh
+++ b/check_jstat.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 #
 # A simple Nagios command that check some statistics of a JAVA JVM.

--- a/check_jstat.sh
+++ b/check_jstat.sh
@@ -43,7 +43,7 @@ function usage() {
     echo "       -c <%>         the critical threshold ratio current/max in %"
 }
 
-VERSION='1.3'
+VERSION='1.4'
 service=''
 pid=''
 ws=-1


### PR DESCRIPTION
check_jstat.sh is a bash script, not a shell script. When trying to run the script on a Solaris box (where /bin/sh is not bash), I got an error.
