### PR TITLE
several check_jstat changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A **Nagios** plugin to get memory statistics of a Java application using **jstat
 The process selection is done either by:
 *  its pid (-p <pid>)
 *  its service name (-s <service-name>) (assuming there is a /var/run/<name>.pid file holding its pid)
-*  its java name (-j <java name>) where the java name depends ob how the java application has been launched (main class or jar/war in case of java -jar) (see jps).
+*  its java name (-j <java name>) where the java name depends on how the java application has been launched (main class or jar/war in case of java -jar) (see jps).
 
 
 It then call `jstat -gc` and `jstat -gccapacity` to catch current and
@@ -19,38 +19,38 @@ If specified (with -w and -c options) values can be checked with
 
 This plugin also attach perfomance data to the output:
 
-    pid=<pid>  
-    heap=<heap-size-used>;<heap-max-size>;<%ratio>;<warning-threshold-%ratio>;<critical-threshold-%ratio>  
-    perm=<perm-size-used>;<perm-max-size>;<%ratio>;<warning-threshold-%ratio>;<critical-threshold-%ratio>  
+    pid=<pid>
+    heap=<heap-size-used>;<heap-max-size>;<%ratio>;<warning-threshold-%ratio>;<critical-threshold-%ratio>
+    perm=<perm-size-used>;<perm-max-size>;<%ratio>;<warning-threshold-%ratio>;<critical-threshold-%ratio>
 
 
 
 Usage:
 ------
 
-    check_jstat.sh -v  
-        Print version and exit"  
-    check_jstat.sh -h  
-        Print this help nd exit  
-    check_jstat.sh -p <pid> [-w <%ratio>] [-c <%ratio>]  
-    check_jstat.sh -s <service> [-w <%ratio>] [-c <%ratio>]  
-    check_jstat.sh -j <java-name> [-w <%ratio>] [-c <%ratio>]  
-        -p <pid>       the PID of process to monitor  
-        -s <service>   the service name of process to monitor  
-        -j <java-name> the java app (see jps) process to monitor  
-                       if this name in blank (-j '') any java app is  
-                       looked for (as long there is only one)  
-        -w <%> the warning threshold ratio current/max in %  
-        -c <%> the critical threshold ratio current/max in %  
-        
+    check_jstat.sh -v
+        Print version and exit"
+    check_jstat.sh -h
+        Print this help nd exit
+    check_jstat.sh -p <pid> [-w <%ratio>] [-c <%ratio>]
+    check_jstat.sh -s <service> [-w <%ratio>] [-c <%ratio>]
+    check_jstat.sh -j <java-name> [-w <%ratio>] [-c <%ratio>]
+        -p <pid>       the PID of process to monitor
+        -s <service>   the service name of process to monitor
+        -j <java-name> the java app (see jps) process to monitor
+                       if this name in blank (-j '') any java app is
+                       looked for (as long there is only one)
+        -w <%> the warning threshold ratio current/max in %
+        -c <%> the critical threshold ratio current/max in %
+
 Configuration:
 --------------
 
 This plugin may require to be run with sudo. In this case add a configuration in /etc/sudoers. For example if nagios is the user that run nagios (or NRPE deamon):
 
-    Defaults:nagios	!requiretty  
+    Defaults:nagios	!requiretty
     nagios ALL=(root) NOPASSWD: /opt/nagios/libexec/check_jstat.sh
-    
+
 check_of
 ========
 
@@ -77,4 +77,4 @@ Usage:
         -w <%>         the warning threshold ratio current/max in %
         -c <%>         the critical threshold ratio current/max in %
 
-    
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The process selection is done either by:
 *  its pid (-p <pid>)
 *  its service name (-s <service-name>) (assuming there is a /var/run/<name>.pid file holding its pid)
 *  its java name (-j <java name>) where the java name depends on how the java application has been launched (main class or jar/war in case of java -jar) (see jps).
+*  its java name or parameters (-J <java name>) (see jps -v).
 
 
 It then call `jstat -gc` and `jstat -gccapacity` to catch current and
@@ -32,16 +33,19 @@ Usage:
         Print version and exit"
     check_jstat.sh -h
         Print this help nd exit
-    check_jstat.sh -p <pid> [-w <%ratio>] [-c <%ratio>]
-    check_jstat.sh -s <service> [-w <%ratio>] [-c <%ratio>]
-    check_jstat.sh -j <java-name> [-w <%ratio>] [-c <%ratio>]
+    check_jstat.sh -p <pid> [-w <%ratio>] [-c <%ratio>] [-P <java-home>]
+    check_jstat.sh -s <service> [-w <%ratio>] [-c <%ratio>] [-P <java-home>]
+    check_jstat.sh -j <java-name> [-w <%ratio>] [-c <%ratio>] [-P <java-home>]
+    check_jstat.sh -J <java-name> [-w <%ratio>] [-c <%ratio>] [-P <java-home>]
         -p <pid>       the PID of process to monitor
         -s <service>   the service name of process to monitor
         -j <java-name> the java app (see jps) process to monitor
                        if this name in blank (-j '') any java app is
                        looked for (as long there is only one)
-        -w <%> the warning threshold ratio current/max in %
-        -c <%> the critical threshold ratio current/max in %
+        -J <java-name> same as -j but checks on 'jps -v' output
+        -P <java-home> use this java installation path
+        -w <%> the warning threshold ratio current/max in % (defaults to 90)
+        -c <%> the critical threshold ratio current/max in % (defaults to 95)
 
 Configuration:
 --------------

--- a/check_jstat.sh
+++ b/check_jstat.sh
@@ -32,16 +32,17 @@ usage() {
     echo "       Print version and exit"
     echo "Usage: $prog -h";
     echo "      Print this help and exit"
-    echo "Usage: $prog -p <pid> [-w <%ratio>] [-c <%ratio>]";
-    echo "Usage: $prog -s <service> [-w <%ratio>] [-c <%ratio>]";
-    echo "Usage: $prog -j <java-name> [-w <%ratio>] [-c <%ratio>]";
-    echo "Usage: $prog -J <java-name> [-w <%ratio>] [-c <%ratio>]";
+    echo "Usage: $prog -p <pid> [-w <%ratio>] [-c <%ratio>] [-P <java-home>]";
+    echo "Usage: $prog -s <service> [-w <%ratio>] [-c <%ratio>] [-P <java-home>]";
+    echo "Usage: $prog -j <java-name> [-w <%ratio>] [-c <%ratio>] [-P <java-home>]";
+    echo "Usage: $prog -J <java-name> [-w <%ratio>] [-c <%ratio>] [-P <java-home>]";
     echo "       -p <pid>       the PID of process to monitor"
     echo "       -s <service>   the service name of process to monitor"
     echo "       -j <java-name> the java app (see jps) process to monitor"
     echo "                      if this name in blank (-j '') any java app is"
     echo "                      looked for (as long there is only one)"
     echo "       -J <java-name> same as -j but checks on 'jps -v' output"
+    echo "       -P <java-home> use this java installation path"
     echo "       -w <%>         the warning threshold ratio current/max in % (defaults to 90)"
     echo "       -c <%>         the critical threshold ratio current/max in % (defaults to 95)"
 }
@@ -53,8 +54,9 @@ ws=90
 cs=95
 use_jps=0
 jps_verbose=0
+java_home=''
 
-while getopts hvp:s:j:J:w:c: opt ; do
+while getopts hvp:s:j:J:P:w:c: opt ; do
     case ${opt} in
     v)  echo "$0 version $VERSION"
         exit 0
@@ -72,6 +74,8 @@ while getopts hvp:s:j:J:w:c: opt ; do
     J)  java_name="${OPTARG}"
         use_jps=1
         jps_verbose=1
+        ;;
+    P)  java_home="${OPTARG}"
         ;;
     w)  ws="${OPTARG}"
         ;;
@@ -100,6 +104,16 @@ if [ -n "$service" -a $use_jps -eq 1 ] ; then
     echo "Only one of -s or -j parameter must be provided"
     usage $0
     exit 3
+fi
+
+if [ -n "${java_home}" ] ; then
+    if [ -x "${java_home}/bin/jstat" ] ; then
+        PATH="${java_home}/bin:${PATH}"
+    else
+        echo "jstat not found in ${java_home}/bin"
+        usage $0
+        exit 3
+    fi
 fi
 
 if [ $use_jps -eq 1 ] ; then

--- a/check_jstat.sh
+++ b/check_jstat.sh
@@ -39,6 +39,7 @@ function usage() {
     echo "       -j <java-name> the java app (see jps) process to monitor"
     echo "                      if this name in blank (-j '') any java app is"
     echo "                      looked for (as long there is only one)"
+    echo "       -J <java-name> same as -j but checks on 'jps -v' output"
     echo "       -w <%>         the warning threshold ratio current/max in %"
     echo "       -c <%>         the critical threshold ratio current/max in %"
 }
@@ -49,8 +50,9 @@ pid=''
 ws=-1
 cs=-1
 use_jps=0
+jps_verbose=0
 
-while getopts hvp:s:j:w:c: opt ; do
+while getopts hvp:s:j:J:w:c: opt ; do
     case ${opt} in
     v)  echo "$0 version $VERSION"
         exit 0
@@ -64,6 +66,10 @@ while getopts hvp:s:j:w:c: opt ; do
         ;;
     j)  java_name="${OPTARG}"
         use_jps=1
+        ;;
+    J)  java_name="${OPTARG}"
+        use_jps=1
+        jps_verbose=1
         ;;
     w)  ws="${OPTARG}"
         ;;
@@ -96,7 +102,11 @@ fi
 
 if [ $use_jps -eq 1 ] ; then
     if [ -n "$java_name" ] ; then
-        java=$(jps | grep "$java_name" 2>/dev/null)
+        if [ "${jps_verbose}" = "1" ]; then
+            java=$(jps -v | grep "$java_name" 2>/dev/null)
+        else
+            java=$(jps | grep "$java_name" 2>/dev/null)
+        fi
     else
         java=$(jps | grep -v Jps 2>/dev/null)
     fi

--- a/check_jstat.sh
+++ b/check_jstat.sh
@@ -166,8 +166,8 @@ pgcmx=$(expr "${12}" : '\([0-9]\+\)')
 #echo "ou=${ou}k ogcmx=${ogcmx}k"
 #echo "pu=${pu}k pgcmx=${pgcmx}k"
 
-heap=$(($eu + $ou))
-heapmx=$(($ygcmx + $ogcmx))
+heap=$((($eu + $ou)*1024))
+heapmx=$((($ygcmx + $ogcmx)*1024))
 heapratio=$((($heap * 100) / $heapmx))
 permratio=$((($pu * 100) / $pgcmx))
 #echo "youg+old=${heap}k, (Max=${heapmx}k, current=${heapratio}%)"

--- a/check_jstat.sh
+++ b/check_jstat.sh
@@ -27,7 +27,7 @@
 
 # Usage helper for this script
 usage() {
-    local prog="${1:-check_jstat.sh}"
+    typeset prog="${1:-check_jstat.sh}"
     echo "Usage: $prog -v";
     echo "       Print version and exit"
     echo "Usage: $prog -h";

--- a/check_jstat.sh
+++ b/check_jstat.sh
@@ -9,7 +9,8 @@
 # It then call jstat -gc and jstat -gccapacity to catch current and
 # maximum 'heap' and 'perm' sizes.
 # What is called 'heap' here is the edden + old generation space,
-# while 'perm' represents the permanent generation space.
+# while 'perm' represents the permanent generation space or metaspace
+# for java 1.8.
 # If specified (with -w and -c options) values can be checked with
 # WARNING or CRITICAL thresholds (apply to both heap and perm regions).
 # This plugin also attach perfomance data to the output:
@@ -34,21 +35,22 @@ usage() {
     echo "Usage: $prog -p <pid> [-w <%ratio>] [-c <%ratio>]";
     echo "Usage: $prog -s <service> [-w <%ratio>] [-c <%ratio>]";
     echo "Usage: $prog -j <java-name> [-w <%ratio>] [-c <%ratio>]";
+    echo "Usage: $prog -J <java-name> [-w <%ratio>] [-c <%ratio>]";
     echo "       -p <pid>       the PID of process to monitor"
     echo "       -s <service>   the service name of process to monitor"
     echo "       -j <java-name> the java app (see jps) process to monitor"
     echo "                      if this name in blank (-j '') any java app is"
     echo "                      looked for (as long there is only one)"
     echo "       -J <java-name> same as -j but checks on 'jps -v' output"
-    echo "       -w <%>         the warning threshold ratio current/max in %"
-    echo "       -c <%>         the critical threshold ratio current/max in %"
+    echo "       -w <%>         the warning threshold ratio current/max in % (defaults to 90)"
+    echo "       -c <%>         the critical threshold ratio current/max in % (defaults to 95)"
 }
 
 VERSION='1.4'
 service=''
 pid=''
-ws=-1
-cs=-1
+ws=90
+cs=95
 use_jps=0
 jps_verbose=0
 
@@ -149,9 +151,9 @@ if [ -z "$gc" ]; then
 fi
 #echo "gc=$gc"
 set -- $gc
-eu=$(expr "${6}" : '\([0-9]*\)')
-ou=$(expr "${8}" : '\([0-9]*\)')
-pu=$(expr "${10}" : '\([0-9]*\)')
+eu=$(($(expr "${6}" : '\([0-9]*\)')*1024))
+ou=$(($(expr "${8}" : '\([0-9]*\)')*1024))
+pu=$(($(expr "${10}" : '\([0-9]*\)')*1024))
 
 gccapacity=$(jstat -gccapacity $pid | tail -1 | sed -e 's/[ ][ ]*/ /g')
 if [ -z "$gccapacity" ]; then
@@ -161,23 +163,35 @@ fi
 
 #echo "gccapacity=$gccapacity"
 set -- $gccapacity
-ygcmx=$(expr "${2}" : '\([0-9]\+\)')
-ogcmx=$(expr "${8}" : '\([0-9]\+\)')
-pgcmx=$(expr "${12}" : '\([0-9]\+\)')
+ygcmx=$(($(expr "${2}" : '\([0-9]*\)')*1024))
+ogcmx=$(($(expr "${8}" : '\([0-9]*\)')*1024))
+pgcmx=$(($(expr "${12}" : '\([0-9]*\)')*1024))
 
 #echo "eu=${eu}k ygcmx=${ygcmx}k"
 #echo "ou=${ou}k ogcmx=${ogcmx}k"
 #echo "pu=${pu}k pgcmx=${pgcmx}k"
 
-heap=$((($eu + $ou)*1024))
-heapmx=$((($ygcmx + $ogcmx)*1024))
+heap=$((($eu + $ou)))
+heapmx=$((($ygcmx)))
 heapratio=$((($heap * 100) / $heapmx))
 permratio=$((($pu * 100) / $pgcmx))
+
+heapw=$(($heapmx * $ws / 100))
+heapc=$(($heapmx * $cs / 100))
+permw=$(($pgcmx * $ws / 100))
+permc=$(($pgcmx * $cs / 100))
+
 #echo "youg+old=${heap}k, (Max=${heapmx}k, current=${heapratio}%)"
 #echo "perm=${pu}k, (Max=${pgcmx}k, current=${permratio}%)"
 
 
-perfdata="pid=$pid heap=$heap;$heapmx;$heapratio;$ws;$cs perm=$pu;$pgcmx;$permratio;$ws;$cs"
+#perfdata="pid=$pid heap=$heap;$heapmx;$heapratio;$ws;$cs perm=$pu;$pgcmx;$permratio;$ws;$cs"
+#perfdata="pid=$pid"
+perfdata=""
+perfdata="${perfdata} heap=${heap}B;$heapw;$heapc;0;$heapmx"
+perfdata="${perfdata} heap_ratio=${heapratio}%;$ws;$cs;0;100"
+perfdata="${perfdata} perm=${pu}B;$permw;$permc;0;$pgcmx"
+perfdata="${perfdata} perm_ratio=${permratio}%;$ws;$cs;0;100"
 
 if [ $cs -gt 0 -a $permratio -ge $cs ]; then
     echo "CRITICAL: jstat process $label critical PermGen (${permratio}% of MaxPermSize)|$perfdata"


### PR DESCRIPTION
My changes:
- ksh compatibility (execution on hpux)
- perfdata more compatible with nagios
- removed pid= in perfdata
- separation of ratio and absolute values
- parameter to match a java process on its arguments
- parameter to use a specific java installation